### PR TITLE
Modifying the URL's to use the new endpoints.

### DIFF
--- a/hidefedora/src/content.js
+++ b/hidefedora/src/content.js
@@ -1,5 +1,5 @@
 var TIME_PERIOD_CHECK_HOURS = 3,
-	JSON_URL = 'https://jhvisser.com/hidefedora/getJSON.php',
+	JSON_URL = 'https://jhvisser.com/hidefedora/reports/profiles.json',
 	fedoras = [],
 	removalMethod = 'hide',
 	showReportButton = true,
@@ -58,7 +58,7 @@ var getParentUrl = function() {
 
 var submitReport = function(profileId, comment) {
 	$.ajax({
-		url: 'https://jhvisser.com/hidefedora/html/submit/submit.php',
+		url: 'https://jhvisser.com/hidefedora/reports',
 		type: 'POST',
 		data: {
 			submit: 1,


### PR DESCRIPTION
I have swapped the end points used to be the new end points used with the framework. 

I have routes registered so that the old endpoints will still work however I'd like to get rid of them if possible. 

Changing the URL's in the Opera and Firefox edition would be ideal too :smile: 
